### PR TITLE
Refine login layout and fix footer positioning

### DIFF
--- a/src/app/(public)/auth/login/page.module.css
+++ b/src/app/(public)/auth/login/page.module.css
@@ -1,0 +1,13 @@
+.wrapper {
+  width: 100%;
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 48px 16px;
+}
+
+.inner {
+  width: 100%;
+  max-width: 420px;
+}

--- a/src/app/(public)/auth/login/page.tsx
+++ b/src/app/(public)/auth/login/page.tsx
@@ -1,11 +1,14 @@
 'use client';
 
 import LoginForm from "@/components/form/LoginForm";
+import styles from "./page.module.css";
 
 export default function Login() {
   return (
-    <div>
-      <LoginForm />
-    </div>
+    <section className={styles.wrapper}>
+      <div className={styles.inner}>
+        <LoginForm />
+      </div>
+    </section>
   );
 }

--- a/src/app/(public)/layout.module.css
+++ b/src/app/(public)/layout.module.css
@@ -11,4 +11,7 @@
   margin: 0 auto;
   width: 100%;
   padding: 16px;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
 }

--- a/src/app/global.css
+++ b/src/app/global.css
@@ -1,11 +1,14 @@
+html,
+body {
+  height: 100%;
+}
+
 body {
   margin: 0;
-  height: 100%;
   background-color: var(--cor-fundo-pagina);
   color: var(--cor-texto-principal);
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
 }
-
 
 :root {
   /* Paleta de Cores Principal */
@@ -30,6 +33,4 @@ body {
   /* Outras Variáveis Úteis */
   --raio-borda-padrao: 4px;
   --sombra-padrao: 0 4px 6px rgba(0, 0, 0, 0.1);
-  margin: 0;
-  height: 100%  ;
 }

--- a/src/components/form/LoginForm.module.css
+++ b/src/components/form/LoginForm.module.css
@@ -1,8 +1,33 @@
 .container {
-   width: 100%;
-   padding: 40px;
-   border-radius: 10px;
-   background-color: #ffffff;
-   border: 1px solid #038a71;
+  width: 100%;
+  padding: 32px;
+  border-radius: 12px;
+  background-color: var(--cor-fundo-card);
+  border: 1px solid var(--cor-borda);
+  box-shadow: var(--sombra-padrao);
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
 
+.title {
+  text-align: center;
+  margin: 0;
+  color: var(--cor-primaria);
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.helper {
+  margin-bottom: 0;
+  text-align: center;
+}
+
+.link {
+  color: var(--cor-destaque);
+  font-weight: 600;
 }

--- a/src/components/form/LoginForm.tsx
+++ b/src/components/form/LoginForm.tsx
@@ -1,4 +1,4 @@
-import { Form, Input, Button, Typography, Col } from "antd";
+import { Form, Input, Button, Typography } from "antd";
 import { MailOutlined, LockOutlined } from "@ant-design/icons";
 import type { ValidateErrorEntity } from "rc-field-form/lib/interface";
 import Link from "next/link";
@@ -20,10 +20,7 @@ const LoginForm: React.FC = () => {
 
   return (
     <div className={styles.container}>
-      <Typography.Title
-        level={2}
-        style={{ textAlign: "center", marginBottom: "2rem" }}
-      >
+      <Typography.Title level={2} className={styles.title}>
         Entrar
       </Typography.Title>
 
@@ -34,6 +31,7 @@ const LoginForm: React.FC = () => {
         onFinish={onFinish}
         onFinishFailed={onFinishFailed}
         autoComplete="off"
+        className={styles.form}
       >
         <Form.Item
           label="Email:"
@@ -62,10 +60,10 @@ const LoginForm: React.FC = () => {
           />
         </Form.Item>
 
-        <Form.Item style={{ marginBottom: "1rem", textAlign: "center" }}>
+        <Form.Item className={styles.helper}>
           <Typography.Text>
             Não possui uma conta?{" "}
-            <Link href="/auth/registro" style={{ color: "#00A78E" }}>
+            <Link href="/auth/registro" className={styles.link}>
               Registre-se
             </Link>
           </Typography.Text>


### PR DESCRIPTION
## Summary
- ensure the public layout stretches its content so the footer remains anchored to the bottom of the viewport
- reorganize the login page structure and styling to center the form and remove inline style redundancies
- adjust global styles and the login form module to use shared design tokens for consistent spacing and colors

## Testing
- npm run lint *(fails: existing lint errors in criar-curso page and middleware)*

------
https://chatgpt.com/codex/tasks/task_e_68e97b9a03dc832a9703e9e7665c27a9