### PR TITLE
Create cadastro screen with two-column auth layout

### DIFF
--- a/src/app/(public)/auth/cadastro/page.module.css
+++ b/src/app/(public)/auth/cadastro/page.module.css
@@ -1,0 +1,11 @@
+.wrapper {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  padding: 16px;
+}
+
+.inner {
+  width: 100%;
+  max-width: 480px;
+}

--- a/src/app/(public)/auth/cadastro/page.tsx
+++ b/src/app/(public)/auth/cadastro/page.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import RegisterForm from "@/components/form/RegisterForm";
+
+import styles from "./page.module.css";
+
+export default function Cadastro() {
+  return (
+    <section className={styles.wrapper}>
+      <div className={styles.inner}>
+        <RegisterForm />
+      </div>
+    </section>
+  );
+}

--- a/src/app/(public)/auth/layout.module.css
+++ b/src/app/(public)/auth/layout.module.css
@@ -1,0 +1,28 @@
+.wrapper {
+  width: 100%;
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 48px 16px;
+}
+
+.row {
+  width: 100%;
+  max-width: 1100px;
+}
+
+.column {
+  display: flex;
+  justify-content: center;
+}
+
+@media (max-width: 991px) {
+  .wrapper {
+    padding: 32px 16px 48px;
+  }
+
+  .column {
+    justify-content: flex-start;
+  }
+}

--- a/src/app/(public)/auth/layout.tsx
+++ b/src/app/(public)/auth/layout.tsx
@@ -1,16 +1,31 @@
 "use client";
-import { Row, Col } from "antd";
+
+import { Col, Row } from "antd";
+
 import ImageContainer from "@/components/imageContainer/ImageContainer";
 
-export default function AuthLayout({
-   children,
-}: {
-   children: React.ReactNode;
-}) {
-   return (
-      <Row gutter={10}>
-         <Col span={12}><ImageContainer/></Col>
-         <Col span={12}>{children}</Col>
+import styles from "./layout.module.css";
+
+type AuthLayoutProps = {
+  children: React.ReactNode;
+};
+
+export default function AuthLayout({ children }: AuthLayoutProps) {
+  return (
+    <div className={styles.wrapper}>
+      <Row
+        gutter={[32, 32]}
+        justify="center"
+        align="middle"
+        className={styles.row}
+      >
+        <Col xs={24} lg={12} className={styles.column}>
+          <ImageContainer />
+        </Col>
+        <Col xs={24} lg={12} className={styles.column}>
+          {children}
+        </Col>
       </Row>
-   );
+    </div>
+  );
 }

--- a/src/app/(public)/auth/registro/page.tsx
+++ b/src/app/(public)/auth/registro/page.tsx
@@ -1,6 +1,0 @@
-
-export default function Registro() {
-  return (
-      <h1>Registro</h1>
-  );
-}

--- a/src/components/form/LoginForm.tsx
+++ b/src/components/form/LoginForm.tsx
@@ -63,8 +63,8 @@ const LoginForm: React.FC = () => {
         <Form.Item className={styles.helper}>
           <Typography.Text>
             Não possui uma conta?{" "}
-            <Link href="/auth/registro" className={styles.link}>
-              Registre-se
+            <Link href="/auth/cadastro" className={styles.link}>
+              Cadastre-se
             </Link>
           </Typography.Text>
         </Form.Item>

--- a/src/components/form/RegisterForm.module.css
+++ b/src/components/form/RegisterForm.module.css
@@ -1,0 +1,56 @@
+.container {
+  width: 100%;
+  padding: 36px 32px;
+  border-radius: 18px;
+  background-color: var(--cor-fundo-card);
+  border: 1px solid var(--cor-borda);
+  box-shadow: var(--sombra-padrao);
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.title {
+  margin: 0;
+  text-align: center;
+  color: var(--cor-primaria);
+}
+
+.subtitle {
+  margin: 0;
+  text-align: center;
+  color: var(--cor-texto-principal);
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.helper {
+  margin-bottom: 0;
+  text-align: center;
+}
+
+.link {
+  color: var(--cor-destaque);
+  font-weight: 600;
+}
+
+@media (max-width: 575px) {
+  .container {
+    padding: 28px 24px;
+    border-radius: 16px;
+  }
+
+  .subtitle {
+    font-size: 15px;
+  }
+}

--- a/src/components/form/RegisterForm.tsx
+++ b/src/components/form/RegisterForm.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import { Button, Form, Input, Typography } from "antd";
+import { LockOutlined, MailOutlined, UserOutlined } from "@ant-design/icons";
+import type { ValidateErrorEntity } from "rc-field-form/lib/interface";
+import Link from "next/link";
+
+import styles from "./RegisterForm.module.css";
+
+interface RegisterFormValues {
+  name: string;
+  email: string;
+  password: string;
+  confirmPassword: string;
+}
+
+const RegisterForm: React.FC = () => {
+  const onFinish = (values: RegisterFormValues) => {
+    console.log("Dados recebidos do formulário de cadastro:", values);
+    alert(`Cadastro realizado para ${values.name}`);
+  };
+
+  const onFinishFailed = (
+    errorInfo: ValidateErrorEntity<RegisterFormValues>
+  ) => {
+    console.log("Falha ao cadastrar:", errorInfo);
+  };
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.header}>
+        <Typography.Title level={2} className={styles.title}>
+          Cadastre-se
+        </Typography.Title>
+        <Typography.Paragraph className={styles.subtitle}>
+          Crie sua conta para acessar os cursos e materiais exclusivos do MOOC
+          IFPR.
+        </Typography.Paragraph>
+      </div>
+
+      <Form
+        name="register"
+        layout="vertical"
+        onFinish={onFinish}
+        onFinishFailed={onFinishFailed}
+        autoComplete="off"
+        className={styles.form}
+      >
+        <Form.Item
+          label="Nome completo"
+          name="name"
+          rules={[{ required: true, message: "Informe seu nome completo." }]}
+        >
+          <Input
+            prefix={<UserOutlined className="site-form-item-icon" />}
+            placeholder="Seu nome"
+            size="large"
+          />
+        </Form.Item>
+
+        <Form.Item
+          label="Email"
+          name="email"
+          rules={[
+            { required: true, message: "Informe seu email." },
+            { type: "email", message: "Digite um email válido." },
+          ]}
+        >
+          <Input
+            prefix={<MailOutlined className="site-form-item-icon" />}
+            placeholder="seuemail@exemplo.com"
+            size="large"
+          />
+        </Form.Item>
+
+        <Form.Item
+          label="Senha"
+          name="password"
+          rules={[
+            { required: true, message: "Crie uma senha." },
+            { min: 6, message: "A senha deve ter pelo menos 6 caracteres." },
+          ]}
+        >
+          <Input.Password
+            prefix={<LockOutlined className="site-form-item-icon" />}
+            placeholder="Digite sua senha"
+            size="large"
+          />
+        </Form.Item>
+
+        <Form.Item
+          label="Confirmar senha"
+          name="confirmPassword"
+          dependencies={["password"]}
+          rules={[
+            { required: true, message: "Confirme sua senha." },
+            ({ getFieldValue }) => ({
+              validator(_, value) {
+                if (!value || getFieldValue("password") === value) {
+                  return Promise.resolve();
+                }
+                return Promise.reject(
+                  new Error("As senhas informadas não coincidem.")
+                );
+              },
+            }),
+          ]}
+        >
+          <Input.Password
+            prefix={<LockOutlined className="site-form-item-icon" />}
+            placeholder="Repita sua senha"
+            size="large"
+          />
+        </Form.Item>
+
+        <Form.Item>
+          <Button type="primary" htmlType="submit" block size="large">
+            Criar conta
+          </Button>
+        </Form.Item>
+
+        <Form.Item className={styles.helper}>
+          <Typography.Text>
+            Já possui uma conta?{" "}
+            <Link href="/auth/login" className={styles.link}>
+              Entrar
+            </Link>
+          </Typography.Text>
+        </Form.Item>
+      </Form>
+    </div>
+  );
+};
+
+export default RegisterForm;

--- a/src/components/imageContainer/ImageContainer.module.css
+++ b/src/components/imageContainer/ImageContainer.module.css
@@ -1,8 +1,96 @@
 .container {
-   width: 100%;
-   padding: 40px;
-   border-radius: 10px;
-   background-color: #ffffff;
-   border: 1px solid #038a71;
+  width: 100%;
+  padding: 48px 40px;
+  border-radius: 24px;
+  background: linear-gradient(135deg, var(--cor-primaria) 0%, var(--cor-primaria-clara) 100%);
+  border: 1px solid rgba(3, 138, 113, 0.4);
+  color: var(--cor-texto-claro);
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  box-shadow: var(--sombra-padrao);
+}
 
+.textGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 20px;
+  line-height: 1.4;
+}
+
+.subtitle {
+  margin: 0;
+  font-weight: 500;
+}
+
+.highlight {
+  margin: 0;
+  font-weight: 700;
+}
+
+.brandGroup {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  font-size: 48px;
+  font-weight: 800;
+  letter-spacing: 1px;
+}
+
+.brandPrimary {
+  color: var(--cor-texto-claro);
+}
+
+.brandSecondary {
+  color: #8ef0d3;
+}
+
+.description {
+  margin: 0;
+  font-size: 16px;
+  max-width: 420px;
+}
+
+.imageWrapper {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}
+
+.image {
+  width: 100%;
+  height: auto;
+  max-width: 420px;
+}
+
+@media (max-width: 991px) {
+  .container {
+    padding: 32px 28px;
+    border-radius: 20px;
+  }
+
+  .brandGroup {
+    font-size: 40px;
+  }
+}
+
+@media (max-width: 575px) {
+  .container {
+    padding: 24px 20px;
+    border-radius: 16px;
+    gap: 20px;
+  }
+
+  .textGroup {
+    font-size: 18px;
+  }
+
+  .brandGroup {
+    font-size: 32px;
+  }
+
+  .description {
+    font-size: 15px;
+  }
 }

--- a/src/components/imageContainer/ImageContainer.tsx
+++ b/src/components/imageContainer/ImageContainer.tsx
@@ -1,10 +1,36 @@
-import React, { JSX } from "react";
+import Image from "next/image";
+
+import pessoasLogin from "@/assets/pessoasLogin.png";
+
 import styles from "./ImageContainer.module.css";
 
-export default function ImageContainer(): JSX.Element {
+export default function ImageContainer() {
   return (
     <div className={styles.container}>
+      <div className={styles.textGroup}>
+        <p className={styles.subtitle}>Aprender é o primeiro passo para se tornar</p>
+        <p className={styles.highlight}>quem você sempre sonhou ser</p>
+      </div>
+
+      <div className={styles.brandGroup}>
+        <span className={styles.brandPrimary}>MOOC</span>
+        <span className={styles.brandSecondary}>IFPR</span>
+      </div>
+
+      <p className={styles.description}>
+        Cursos gratuitos, certificados reconhecidos e uma comunidade acessível para
+        você crescer no seu ritmo.
+      </p>
+
+      <div className={styles.imageWrapper}>
+        <Image
+          src={pessoasLogin}
+          alt="Ilustração de pessoas estudando online"
+          priority
+          sizes="(max-width: 991px) 100vw, 420px"
+          className={styles.image}
+        />
+      </div>
     </div>
   );
 }
-

--- a/src/components/layout/header/HeaderPublic.tsx
+++ b/src/components/layout/header/HeaderPublic.tsx
@@ -52,7 +52,7 @@ export default function HeaderPublic() {
           <Link href="/auth/login">
             <Button>Entrar</Button>
           </Link>
-          <Link href="/auth/registro">
+          <Link href="/auth/cadastro">
             <Button type="primary">Cadastrar</Button>
           </Link>
         </div>


### PR DESCRIPTION
## Summary
- add a dedicated /auth/cadastro page with a new registration form component styled to match the design
- enhance the shared auth layout with a centered two-column grid and a featured illustration card that uses the pessoasLogin asset
- update navigation and login form links to point to the new cadastro route and remove the unused registro page

## Testing
- npm run lint *(fails: existing lint errors in protected course pages and middleware)*

------
https://chatgpt.com/codex/tasks/task_e_68f16fc78770832a850b1700ace584e0