### PR TITLE
Integrate auth forms with backend services

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "antd": "^5.27.4",
+        "dayjs": "^1.11.18",
         "next": "15.4.6",
         "primeicons": "^7.0.0",
         "primereact": "^10.9.6",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "antd": "^5.27.4",
+    "dayjs": "^1.11.18",
     "next": "15.4.6",
     "primeicons": "^7.0.0",
     "primereact": "^10.9.6",

--- a/src/components/form/LoginForm.tsx
+++ b/src/components/form/LoginForm.tsx
@@ -1,18 +1,40 @@
-import { Form, Input, Button, Typography } from "antd";
+"use client";
+
+import { useState } from "react";
+import { Form, Input, Button, Typography, message } from "antd";
 import { MailOutlined, LockOutlined } from "@ant-design/icons";
 import type { ValidateErrorEntity } from "rc-field-form/lib/interface";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import styles from "./LoginForm.module.css";
+import { login } from "@/services/authService";
 
 interface LoginFormValues {
   email: string;
-  password?: string;
+  password: string;
 }
 
 const LoginForm: React.FC = () => {
-  const onFinish = (values: LoginFormValues) => {
-    console.log("Dados recebidos do formulário: ", values); // Aqui você implementaria a lógica de autenticação
-    alert(`Login com Email: ${values.email}`);
+  const router = useRouter();
+  const [loading, setLoading] = useState(false);
+
+  const onFinish = async (values: LoginFormValues) => {
+    setLoading(true);
+    try {
+      const { token } = await login(values);
+      localStorage.setItem("jwt_token", token);
+      message.success("Login realizado com sucesso!");
+      router.push("/dashboard");
+    } catch (error) {
+      console.error("Falha ao autenticar:", error);
+      const errorMessage =
+        error instanceof Error
+          ? error.message
+          : "Não foi possível realizar o login.";
+      message.error(errorMessage);
+    } finally {
+      setLoading(false);
+    }
   };
   const onFinishFailed = (errorInfo: ValidateErrorEntity<LoginFormValues>) => {
     console.log("Falha ao submeter:", errorInfo);
@@ -70,8 +92,14 @@ const LoginForm: React.FC = () => {
         </Form.Item>
 
         <Form.Item>
-          <Button type="primary" htmlType="submit" block size="large">
-            Enviar
+          <Button
+            type="primary"
+            htmlType="submit"
+            block
+            size="large"
+            loading={loading}
+          >
+            Entrar
           </Button>
         </Form.Item>
       </Form>

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,0 +1,59 @@
+export const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8080/mooc";
+
+export class ApiError extends Error {
+  status: number;
+  details: unknown;
+
+  constructor(message: string, status: number, details: unknown = null) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+    this.details = details;
+  }
+}
+
+async function parseResponseBody(response: Response) {
+  const contentType = response.headers.get("content-type");
+
+  if (contentType?.includes("application/json")) {
+    return response.json();
+  }
+
+  const text = await response.text();
+
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+export async function apiRequest<TResponse>(
+  path: string,
+  init: RequestInit = {}
+): Promise<TResponse> {
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    cache: "no-store",
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      ...(init.headers ?? {}),
+    },
+  });
+
+  const data = await parseResponseBody(response);
+
+  if (!response.ok) {
+    const message =
+      (typeof data === "object" && data !== null && "message" in data
+        ? String((data as Record<string, unknown>).message)
+        : undefined) ||
+      (typeof data === "string" && data.trim().length > 0 ? data : undefined) ||
+      "Erro ao realizar requisição.";
+
+    throw new ApiError(message, response.status, data);
+  }
+
+  return data as TResponse;
+}

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -1,0 +1,67 @@
+import { apiRequest, ApiError } from "./api";
+
+export interface LoginPayload {
+  email: string;
+  password: string;
+}
+
+export interface RegisterPayload {
+  fullName: string;
+  cpf: string;
+  birthDate: string;
+  email: string;
+  password: string;
+}
+
+interface LoginResponseShape {
+  access_token?: string;
+  token?: string;
+  data?: LoginResponseShape;
+  [key: string]: unknown;
+}
+
+function extractToken(data: LoginResponseShape | null | undefined): string | null {
+  if (!data || typeof data !== "object") {
+    return null;
+  }
+
+  if (typeof data.access_token === "string" && data.access_token.length > 0) {
+    return data.access_token;
+  }
+
+  if (typeof data.token === "string" && data.token.length > 0) {
+    return data.token;
+  }
+
+  if (data.data && typeof data.data === "object") {
+    return extractToken(data.data as LoginResponseShape);
+  }
+
+  return null;
+}
+
+export async function login(payload: LoginPayload) {
+  const data = await apiRequest<LoginResponseShape>("/auth/login", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+
+  const token = extractToken(data);
+
+  if (!token) {
+    throw new ApiError(
+      "Token de autenticação não encontrado na resposta do servidor.",
+      500,
+      data
+    );
+  }
+
+  return { token, data };
+}
+
+export async function registerUser(payload: RegisterPayload) {
+  return apiRequest<unknown>("/users/register", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+}


### PR DESCRIPTION
## Summary
- add a shared API helper and auth service to centralize backend requests
- connect the login form to the backend authentication endpoint, persisting the JWT token and handling user feedback
- extend the registration form with required fields, validation, and submission to the user creation endpoint, leveraging dayjs for date formatting

## Testing
- npm run lint *(fails due to existing lint errors in untouched files)*

------
https://chatgpt.com/codex/tasks/task_e_68f568e006e4832aaebe6eb748a8bfde