### PR TITLE
Implement in-memory API for MOOC endpoints

### DIFF
--- a/src/app/api/_lib/auth.ts
+++ b/src/app/api/_lib/auth.ts
@@ -1,0 +1,49 @@
+import { NextRequest } from 'next/server';
+import { db } from './store';
+import { User, UserRole } from './types';
+
+export interface AuthResult {
+  user: User;
+}
+
+const getAuthorizationHeader = (request: NextRequest) =>
+  request.headers.get('authorization') || request.headers.get('Authorization');
+
+export const authenticateRequest = (request: NextRequest, roles?: UserRole[]): AuthResult | Response => {
+  const authorization = getAuthorizationHeader(request);
+
+  if (!authorization || !authorization.startsWith('Bearer ')) {
+    return new Response(JSON.stringify({ message: 'Token não informado.' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const token = authorization.substring(7).trim();
+  const session = db.sessions.find((item) => item.token === token);
+
+  if (!session) {
+    return new Response(JSON.stringify({ message: 'Sessão inválida ou expirada.' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const user = db.users.find((item) => item.id === session.userId);
+
+  if (!user) {
+    return new Response(JSON.stringify({ message: 'Usuário não encontrado.' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  if (roles && !roles.includes(user.role)) {
+    return new Response(JSON.stringify({ message: 'Usuário sem permissão para executar esta ação.' }), {
+      status: 403,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  return { user };
+};

--- a/src/app/api/_lib/store.ts
+++ b/src/app/api/_lib/store.ts
@@ -1,0 +1,122 @@
+import { Campus, Course, Enrollment, KnowledgeArea, Lesson, LessonProgress, Session, User } from './types';
+
+const now = () => new Date().toISOString();
+
+let userIdCounter = 2;
+let knowledgeAreaIdCounter = 2;
+let campusIdCounter = 2;
+let courseIdCounter = 2;
+let lessonIdCounter = 1;
+let enrollmentIdCounter = 1;
+let lessonProgressIdCounter = 1;
+
+const users: User[] = [
+  {
+    id: 1,
+    fullName: 'Administrador',
+    cpf: '00000000000',
+    birthDate: '1990-01-01',
+    email: 'admin@mooc.ifpr.edu.br',
+    password: 'admin123',
+    role: 'admin',
+    createdAt: now(),
+    updatedAt: now(),
+  },
+];
+
+const knowledgeAreas: KnowledgeArea[] = [
+  {
+    id: 1,
+    name: 'Tecnologia da Informação',
+    visible: true,
+    createdAt: now(),
+    updatedAt: now(),
+  },
+];
+
+const campuses: Campus[] = [
+  {
+    id: 1,
+    name: 'IFPR Campus Cascavel',
+    visible: true,
+    createdAt: now(),
+    updatedAt: now(),
+  },
+];
+
+const courses: Course[] = [
+  {
+    id: 1,
+    name: 'Introdução à Programação',
+    description: 'Curso introdutório de lógica de programação e fundamentos de algoritmos.',
+    knowledgeAreaId: 1,
+    campusId: 1,
+    professorName: 'Prof. Maria Souza',
+    workload: 40,
+    visible: true,
+    createdAt: now(),
+    updatedAt: now(),
+  },
+];
+
+const lessons: Lesson[] = [];
+const enrollments: Enrollment[] = [];
+const lessonProgress: LessonProgress[] = [];
+const sessions: Session[] = [];
+
+export const db = {
+  users,
+  knowledgeAreas,
+  campuses,
+  courses,
+  lessons,
+  enrollments,
+  lessonProgress,
+  sessions,
+};
+
+export const counters = {
+  get user() {
+    return userIdCounter++;
+  },
+  get knowledgeArea() {
+    return knowledgeAreaIdCounter++;
+  },
+  get campus() {
+    return campusIdCounter++;
+  },
+  get course() {
+    return courseIdCounter++;
+  },
+  get lesson() {
+    return lessonIdCounter++;
+  },
+  get enrollment() {
+    return enrollmentIdCounter++;
+  },
+  get lessonProgress() {
+    return lessonProgressIdCounter++;
+  },
+};
+
+export const resetLessonOrder = (courseId: number) => {
+  const courseLessons = lessons
+    .filter((lesson) => lesson.courseId === courseId)
+    .sort((a, b) => a.ordemAula - b.ordemAula);
+  courseLessons.forEach((lesson, index) => {
+    lesson.ordemAula = index + 1;
+    lesson.updatedAt = now();
+  });
+};
+
+export const findCourseLessons = (courseId: number) =>
+  lessons.filter((lesson) => lesson.courseId === courseId);
+
+export const touchCourse = (courseId: number) => {
+  const course = courses.find((item) => item.id === courseId);
+  if (course) {
+    course.updatedAt = now();
+  }
+};
+
+export const createTimestamp = now;

--- a/src/app/api/_lib/types.ts
+++ b/src/app/api/_lib/types.ts
@@ -1,0 +1,85 @@
+export type UserRole = 'admin' | 'student';
+
+export interface User {
+  id: number;
+  fullName: string;
+  cpf: string;
+  birthDate: string;
+  email: string;
+  password: string;
+  role: UserRole;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface KnowledgeArea {
+  id: number;
+  name: string;
+  visible: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface Campus {
+  id: number;
+  name: string;
+  visible: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface Course {
+  id: number;
+  name: string;
+  description: string;
+  knowledgeAreaId: number;
+  campusId: number;
+  professorName: string;
+  workload: number;
+  visible: boolean;
+  thumbnail?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface Lesson {
+  id: number;
+  courseId: number;
+  titulo: string;
+  descricao: string;
+  urlVideo: string;
+  ordemAula: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface Enrollment {
+  id: number;
+  userId: number;
+  cursoId: number;
+  concluido: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface LessonProgress {
+  id: number;
+  enrollmentId: number;
+  lessonId: number;
+  concluido: boolean;
+  updatedAt: string;
+}
+
+export interface Session {
+  token: string;
+  userId: number;
+  createdAt: number;
+}
+
+export interface PagedResult<T> {
+  content: T[];
+  page: number;
+  size: number;
+  totalItems: number;
+  totalPages: number;
+}

--- a/src/app/api/_lib/utils.ts
+++ b/src/app/api/_lib/utils.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from 'next/server';
+import { PagedResult } from './types';
+
+export const jsonResponse = (data: unknown, status = 200) =>
+  NextResponse.json(data, { status });
+
+export const errorResponse = (message: string, status = 400) =>
+  NextResponse.json({ message }, { status });
+
+export const paginate = <T>(items: T[], page = 0, size = 10): PagedResult<T> => {
+  const pageNumber = Number.isFinite(page) && page >= 0 ? page : 0;
+  const pageSize = Number.isFinite(size) && size > 0 ? size : 10;
+  const start = pageNumber * pageSize;
+  const end = start + pageSize;
+  const content = items.slice(start, end);
+  const totalItems = items.length;
+  const totalPages = Math.max(1, Math.ceil(totalItems / pageSize));
+
+  return {
+    content,
+    page: pageNumber,
+    size: pageSize,
+    totalItems,
+    totalPages,
+  };
+};

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest } from 'next/server';
+import { createTimestamp, db } from '../../_lib/store';
+import { errorResponse, jsonResponse } from '../../_lib/utils';
+
+const sanitizeUser = (userId: number) => {
+  const user = db.users.find((item) => item.id === userId);
+  if (!user) {
+    return null;
+  }
+  const { password: _password, ...publicUser } = user;
+  void _password;
+  return publicUser;
+};
+
+const createToken = (userId: number) => {
+  const random = Math.random().toString(36).substring(2);
+  const base = Buffer.from(`${userId}:${Date.now()}:${random}`).toString('base64');
+  return base.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+};
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { email, password } = body ?? {};
+
+    if (!email || !password) {
+      return errorResponse('E-mail e senha são obrigatórios.', 400);
+    }
+
+    const user = db.users.find((item) => item.email.toLowerCase() === String(email).toLowerCase());
+
+    if (!user || user.password !== password) {
+      return errorResponse('Credenciais inválidas.', 401);
+    }
+
+    const token = createToken(user.id);
+    const sessionIndex = db.sessions.findIndex((item) => item.userId === user.id);
+
+    if (sessionIndex >= 0) {
+      db.sessions[sessionIndex] = { token, userId: user.id, createdAt: Date.now() };
+    } else {
+      db.sessions.push({ token, userId: user.id, createdAt: Date.now() });
+    }
+
+    user.updatedAt = createTimestamp();
+
+    return jsonResponse({ access_token: token, user: sanitizeUser(user.id) });
+  } catch (error) {
+    console.error(error);
+    return errorResponse('Não foi possível processar a requisição.', 500);
+  }
+}

--- a/src/app/api/campus/route.ts
+++ b/src/app/api/campus/route.ts
@@ -1,0 +1,82 @@
+import { NextRequest } from 'next/server';
+import { authenticateRequest } from '../_lib/auth';
+import { counters, createTimestamp, db } from '../_lib/store';
+import { errorResponse, jsonResponse, paginate } from '../_lib/utils';
+
+export async function POST(request: NextRequest) {
+  const auth = authenticateRequest(request, ['admin']);
+  if (auth instanceof Response) {
+    return auth;
+  }
+
+  try {
+    const body = await request.json();
+    const { name, visible } = body ?? {};
+
+    if (!name || typeof visible !== 'boolean') {
+      return errorResponse('Campos "name" e "visible" são obrigatórios.', 400);
+    }
+
+    const exists = db.campuses.some((item) => item.name.toLowerCase() === String(name).toLowerCase());
+
+    if (exists) {
+      return errorResponse('Campus já cadastrado.', 409);
+    }
+
+    const id = counters.campus;
+    const timestamp = createTimestamp();
+
+    const campus = {
+      id,
+      name,
+      visible,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    };
+
+    db.campuses.push(campus);
+
+    return jsonResponse({ campus }, 201);
+  } catch (error) {
+    console.error(error);
+    return errorResponse('Não foi possível processar a requisição.', 500);
+  }
+}
+
+export async function GET(request: NextRequest) {
+  const auth = authenticateRequest(request);
+  if (auth instanceof Response) {
+    return auth;
+  }
+
+  const searchParams = request.nextUrl.searchParams;
+  const name = searchParams.get('name');
+  const active = searchParams.get('active');
+  const page = Number(searchParams.get('page') ?? '0');
+  const size = Number(searchParams.get('size') ?? '10');
+  const direction = (searchParams.get('direction') ?? 'asc').toLowerCase();
+
+  let items = [...db.campuses];
+
+  if (name) {
+    items = items.filter((item) => item.name.toLowerCase().includes(name.toLowerCase()));
+  }
+
+  if (active !== null) {
+    if (['true', 'false'].includes(active.toLowerCase())) {
+      const activeFlag = active.toLowerCase() === 'true';
+      items = items.filter((item) => item.visible === activeFlag);
+    }
+  }
+
+  items.sort((a, b) => {
+    if (direction === 'desc') {
+      return b.name.localeCompare(a.name);
+    }
+    return a.name.localeCompare(b.name);
+  });
+
+  const result = paginate(items, Number.isNaN(page) ? 0 : page, Number.isNaN(size) ? 10 : size);
+
+  return jsonResponse(result);
+}

--- a/src/app/api/courses/[courseId]/lessons/[lessonId]/route.ts
+++ b/src/app/api/courses/[courseId]/lessons/[lessonId]/route.ts
@@ -1,0 +1,83 @@
+import { NextRequest } from 'next/server';
+import { authenticateRequest } from '../../../../_lib/auth';
+import { createTimestamp, db, touchCourse } from '../../../../_lib/store';
+import { errorResponse, jsonResponse } from '../../../../_lib/utils';
+import { getCourseById } from '../../../_utils';
+
+const parseId = (value: string) => {
+  const id = Number(value);
+  return Number.isNaN(id) ? null : id;
+};
+
+const findLesson = (courseId: number, lessonId: number) =>
+  db.lessons.find((lesson) => lesson.courseId === courseId && lesson.id === lessonId);
+
+export async function GET(request: NextRequest, { params }: { params: { courseId: string; lessonId: string } }) {
+  const auth = authenticateRequest(request);
+  if (auth instanceof Response) {
+    return auth;
+  }
+
+  const courseId = parseId(params.courseId);
+  const lessonId = parseId(params.lessonId);
+
+  if (courseId === null || lessonId === null) {
+    return errorResponse('Identificador inválido.', 400);
+  }
+
+  const course = getCourseById(courseId);
+  if (!course) {
+    return errorResponse('Curso não encontrado.', 404);
+  }
+
+  const lesson = findLesson(courseId, lessonId);
+  if (!lesson) {
+    return errorResponse('Aula não encontrada.', 404);
+  }
+
+  return jsonResponse({ lesson });
+}
+
+export async function PUT(request: NextRequest, { params }: { params: { courseId: string; lessonId: string } }) {
+  const auth = authenticateRequest(request, ['admin']);
+  if (auth instanceof Response) {
+    return auth;
+  }
+
+  const courseId = parseId(params.courseId);
+  const lessonId = parseId(params.lessonId);
+
+  if (courseId === null || lessonId === null) {
+    return errorResponse('Identificador inválido.', 400);
+  }
+
+  const course = getCourseById(courseId);
+  if (!course) {
+    return errorResponse('Curso não encontrado.', 404);
+  }
+
+  const lesson = findLesson(courseId, lessonId);
+  if (!lesson) {
+    return errorResponse('Aula não encontrada.', 404);
+  }
+
+  try {
+    const body = await request.json();
+    const { titulo, descricao, urlVideo } = body ?? {};
+
+    if (!titulo || !descricao || !urlVideo) {
+      return errorResponse('Campos "titulo", "descricao" e "urlVideo" são obrigatórios.', 400);
+    }
+
+    lesson.titulo = titulo;
+    lesson.descricao = descricao;
+    lesson.urlVideo = urlVideo;
+    lesson.updatedAt = createTimestamp();
+    touchCourse(courseId);
+
+    return jsonResponse({ lesson });
+  } catch (error) {
+    console.error(error);
+    return errorResponse('Não foi possível processar a requisição.', 500);
+  }
+}

--- a/src/app/api/courses/[courseId]/lessons/reorder/route.ts
+++ b/src/app/api/courses/[courseId]/lessons/reorder/route.ts
@@ -1,0 +1,71 @@
+import { NextRequest } from 'next/server';
+import { authenticateRequest } from '../../../../_lib/auth';
+import { db, resetLessonOrder, touchCourse } from '../../../../_lib/store';
+import { errorResponse, jsonResponse } from '../../../../_lib/utils';
+import { getCourseById } from '../../../_utils';
+
+const parseId = (value: string) => {
+  const id = Number(value);
+  return Number.isNaN(id) ? null : id;
+};
+
+interface AulaReorder {
+  id: number;
+  ordemAula: number;
+}
+
+export async function PATCH(request: NextRequest, { params }: { params: { courseId: string } }) {
+  const auth = authenticateRequest(request, ['admin']);
+  if (auth instanceof Response) {
+    return auth;
+  }
+
+  const courseId = parseId(params.courseId);
+  if (courseId === null) {
+    return errorResponse('Identificador de curso inválido.', 400);
+  }
+
+  const course = getCourseById(courseId);
+  if (!course) {
+    return errorResponse('Curso não encontrado.', 404);
+  }
+
+  try {
+    const body = await request.json();
+    const aulas = Array.isArray(body?.aulas) ? (body.aulas as AulaReorder[]) : [];
+
+    if (!aulas.length) {
+      return errorResponse('Lista de aulas é obrigatória.', 400);
+    }
+
+    const lessonIds = new Set<number>();
+
+    for (const aula of aulas) {
+      if (typeof aula.id !== 'number' || typeof aula.ordemAula !== 'number') {
+        return errorResponse('Estrutura da lista de aulas inválida.', 400);
+      }
+      lessonIds.add(aula.id);
+      const lesson = db.lessons.find((item) => item.courseId === courseId && item.id === aula.id);
+      if (!lesson) {
+        return errorResponse(`Aula ${aula.id} não pertence ao curso informado.`, 404);
+      }
+      lesson.ordemAula = aula.ordemAula;
+    }
+
+    if (lessonIds.size !== aulas.length) {
+      return errorResponse('Existem aulas duplicadas na solicitação.', 400);
+    }
+
+    resetLessonOrder(courseId);
+    touchCourse(courseId);
+
+    const updatedLessons = db.lessons
+      .filter((lesson) => lesson.courseId === courseId)
+      .sort((a, b) => a.ordemAula - b.ordemAula);
+
+    return jsonResponse({ lessons: updatedLessons });
+  } catch (error) {
+    console.error(error);
+    return errorResponse('Não foi possível processar a requisição.', 500);
+  }
+}

--- a/src/app/api/courses/[courseId]/lessons/route.ts
+++ b/src/app/api/courses/[courseId]/lessons/route.ts
@@ -1,0 +1,80 @@
+import { NextRequest } from 'next/server';
+import { authenticateRequest } from '../../../_lib/auth';
+import { counters, createTimestamp, db, findCourseLessons, touchCourse } from '../../../_lib/store';
+import { errorResponse, jsonResponse } from '../../../_lib/utils';
+import { getCourseById } from '../../_utils';
+
+const parseId = (value: string) => {
+  const id = Number(value);
+  return Number.isNaN(id) ? null : id;
+};
+
+export async function POST(request: NextRequest, { params }: { params: { courseId: string } }) {
+  const auth = authenticateRequest(request, ['admin']);
+  if (auth instanceof Response) {
+    return auth;
+  }
+
+  const courseId = parseId(params.courseId);
+  if (courseId === null) {
+    return errorResponse('Identificador de curso inválido.', 400);
+  }
+
+  const course = getCourseById(courseId);
+  if (!course) {
+    return errorResponse('Curso não encontrado.', 404);
+  }
+
+  try {
+    const body = await request.json();
+    const { titulo, descricao, urlVideo } = body ?? {};
+
+    if (!titulo || !descricao || !urlVideo) {
+      return errorResponse('Campos "titulo", "descricao" e "urlVideo" são obrigatórios.', 400);
+    }
+
+    const id = counters.lesson;
+    const timestamp = createTimestamp();
+    const ordemAula = findCourseLessons(courseId).length + 1;
+
+    const lesson = {
+      id,
+      courseId,
+      titulo,
+      descricao,
+      urlVideo,
+      ordemAula,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    };
+
+    db.lessons.push(lesson);
+    touchCourse(courseId);
+
+    return jsonResponse({ lesson }, 201);
+  } catch (error) {
+    console.error(error);
+    return errorResponse('Não foi possível processar a requisição.', 500);
+  }
+}
+
+export async function GET(request: NextRequest, { params }: { params: { courseId: string } }) {
+  const auth = authenticateRequest(request);
+  if (auth instanceof Response) {
+    return auth;
+  }
+
+  const courseId = parseId(params.courseId);
+  if (courseId === null) {
+    return errorResponse('Identificador de curso inválido.', 400);
+  }
+
+  const course = getCourseById(courseId);
+  if (!course) {
+    return errorResponse('Curso não encontrado.', 404);
+  }
+
+  const lessons = findCourseLessons(courseId).sort((a, b) => a.ordemAula - b.ordemAula);
+
+  return jsonResponse({ lessons });
+}

--- a/src/app/api/courses/[id]/route.ts
+++ b/src/app/api/courses/[id]/route.ts
@@ -1,0 +1,113 @@
+import { NextRequest } from 'next/server';
+import { authenticateRequest } from '../../_lib/auth';
+import { createTimestamp, db } from '../../_lib/store';
+import { errorResponse, jsonResponse } from '../../_lib/utils';
+import { getCourseById, serializeCourse } from '../_utils';
+
+const parseId = (value: string) => {
+  const id = Number(value);
+  return Number.isNaN(id) ? null : id;
+};
+
+export async function GET(request: NextRequest, { params }: { params: { id: string } }) {
+  const auth = authenticateRequest(request);
+  if (auth instanceof Response) {
+    return auth;
+  }
+
+  const id = parseId(params.id);
+  if (id === null) {
+    return errorResponse('Identificador inválido.', 400);
+  }
+
+  const course = getCourseById(id);
+  if (!course) {
+    return errorResponse('Curso não encontrado.', 404);
+  }
+
+  return jsonResponse({ course: serializeCourse(course) });
+}
+
+export async function PUT(request: NextRequest, { params }: { params: { id: string } }) {
+  const auth = authenticateRequest(request, ['admin']);
+  if (auth instanceof Response) {
+    return auth;
+  }
+
+  const id = parseId(params.id);
+  if (id === null) {
+    return errorResponse('Identificador inválido.', 400);
+  }
+
+  const course = getCourseById(id);
+  if (!course) {
+    return errorResponse('Curso não encontrado.', 404);
+  }
+
+  try {
+    const body = await request.json();
+    const { name, description, knowledgeAreaId, campusId, professorName, workload, visible } = body ?? {};
+
+    if (!name || !description || !knowledgeAreaId || !campusId || !professorName || !workload || typeof visible !== 'boolean') {
+      return errorResponse('Campos obrigatórios não foram preenchidos.', 400);
+    }
+
+    const knowledgeArea = db.knowledgeAreas.find((item) => item.id === Number(knowledgeAreaId));
+    if (!knowledgeArea) {
+      return errorResponse('Área de conhecimento não encontrada.', 404);
+    }
+
+    const campus = db.campuses.find((item) => item.id === Number(campusId));
+    if (!campus) {
+      return errorResponse('Campus não encontrado.', 404);
+    }
+
+    course.name = name;
+    course.description = description;
+    course.knowledgeAreaId = Number(knowledgeAreaId);
+    course.campusId = Number(campusId);
+    course.professorName = professorName;
+    course.workload = Number(workload);
+    course.visible = visible;
+    course.updatedAt = createTimestamp();
+
+    return jsonResponse({ course: serializeCourse(course) });
+  } catch (error) {
+    console.error(error);
+    return errorResponse('Não foi possível processar a requisição.', 500);
+  }
+}
+
+export async function PATCH(request: NextRequest, { params }: { params: { id: string } }) {
+  const auth = authenticateRequest(request, ['admin']);
+  if (auth instanceof Response) {
+    return auth;
+  }
+
+  const id = parseId(params.id);
+  if (id === null) {
+    return errorResponse('Identificador inválido.', 400);
+  }
+
+  const course = getCourseById(id);
+  if (!course) {
+    return errorResponse('Curso não encontrado.', 404);
+  }
+
+  try {
+    const body = await request.json();
+    const { visible } = body ?? {};
+
+    if (typeof visible !== 'boolean') {
+      return errorResponse('Campo "visible" é obrigatório.', 400);
+    }
+
+    course.visible = visible;
+    course.updatedAt = createTimestamp();
+
+    return jsonResponse({ course: serializeCourse(course) });
+  } catch (error) {
+    console.error(error);
+    return errorResponse('Não foi possível processar a requisição.', 500);
+  }
+}

--- a/src/app/api/courses/[id]/thumbnail/route.ts
+++ b/src/app/api/courses/[id]/thumbnail/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest } from 'next/server';
+import { authenticateRequest } from '../../../_lib/auth';
+import { createTimestamp } from '../../../_lib/store';
+import { errorResponse, jsonResponse } from '../../../_lib/utils';
+import { getCourseById, serializeCourse } from '../../_utils';
+
+const parseId = (value: string) => {
+  const id = Number(value);
+  return Number.isNaN(id) ? null : id;
+};
+
+const findThumbnailFile = (formData: FormData): File | null => {
+  for (const [key, value] of formData.entries()) {
+    if (typeof value === 'object' && 'arrayBuffer' in value) {
+      if (key.trim().toLowerCase() === 'thumbnail') {
+        return value as File;
+      }
+    }
+  }
+  return null;
+};
+
+export async function POST(request: NextRequest, { params }: { params: { id: string } }) {
+  const auth = authenticateRequest(request, ['admin']);
+  if (auth instanceof Response) {
+    return auth;
+  }
+
+  const id = parseId(params.id);
+  if (id === null) {
+    return errorResponse('Identificador inválido.', 400);
+  }
+
+  const course = getCourseById(id);
+  if (!course) {
+    return errorResponse('Curso não encontrado.', 404);
+  }
+
+  try {
+    const formData = await request.formData();
+    const file = findThumbnailFile(formData);
+
+    if (!file) {
+      return errorResponse('Arquivo "thumbnail" é obrigatório.', 400);
+    }
+
+    const arrayBuffer = await file.arrayBuffer();
+    const buffer = Buffer.from(arrayBuffer);
+    const base64 = buffer.toString('base64');
+    const mimeType = file.type || 'application/octet-stream';
+
+    course.thumbnail = `data:${mimeType};base64,${base64}`;
+    course.updatedAt = createTimestamp();
+
+    return jsonResponse({ course: serializeCourse(course) });
+  } catch (error) {
+    console.error(error);
+    return errorResponse('Não foi possível processar a requisição.', 500);
+  }
+}

--- a/src/app/api/courses/_utils.ts
+++ b/src/app/api/courses/_utils.ts
@@ -1,0 +1,24 @@
+import { db } from '../_lib/store';
+import { Course } from '../_lib/types';
+
+export const getCourseById = (id: number): Course | undefined =>
+  db.courses.find((item) => item.id === id);
+
+export const serializeCourse = (course: Course | undefined) => {
+  if (!course) {
+    return null;
+  }
+
+  const knowledgeArea = db.knowledgeAreas.find((item) => item.id === course.knowledgeAreaId);
+  const campus = db.campuses.find((item) => item.id === course.campusId);
+  const lessons = db.lessons
+    .filter((lesson) => lesson.courseId === course.id)
+    .sort((a, b) => a.ordemAula - b.ordemAula);
+
+  return {
+    ...course,
+    knowledgeArea,
+    campus,
+    lessons,
+  };
+};

--- a/src/app/api/courses/route.ts
+++ b/src/app/api/courses/route.ts
@@ -1,0 +1,101 @@
+import { NextRequest } from 'next/server';
+import { authenticateRequest } from '../_lib/auth';
+import { counters, createTimestamp, db } from '../_lib/store';
+import { errorResponse, jsonResponse, paginate } from '../_lib/utils';
+import { serializeCourse, getCourseById } from './_utils';
+
+export async function POST(request: NextRequest) {
+  const auth = authenticateRequest(request, ['admin']);
+  if (auth instanceof Response) {
+    return auth;
+  }
+
+  try {
+    const body = await request.json();
+    const { name, description, knowledgeAreaId, campusId, professorName, workload, visible } = body ?? {};
+
+    if (!name || !description || !knowledgeAreaId || !campusId || !professorName || !workload || typeof visible !== 'boolean') {
+      return errorResponse('Campos obrigatórios não foram preenchidos.', 400);
+    }
+
+    const knowledgeArea = db.knowledgeAreas.find((item) => item.id === Number(knowledgeAreaId));
+    if (!knowledgeArea) {
+      return errorResponse('Área de conhecimento não encontrada.', 404);
+    }
+
+    const campus = db.campuses.find((item) => item.id === Number(campusId));
+    if (!campus) {
+      return errorResponse('Campus não encontrado.', 404);
+    }
+
+    const id = counters.course;
+    const timestamp = createTimestamp();
+
+    const course = {
+      id,
+      name,
+      description,
+      knowledgeAreaId: Number(knowledgeAreaId),
+      campusId: Number(campusId),
+      professorName,
+      workload: Number(workload),
+      visible,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    };
+
+    db.courses.push(course);
+
+    return jsonResponse({ course: serializeCourse(getCourseById(id)) }, 201);
+  } catch (error) {
+    console.error(error);
+    return errorResponse('Não foi possível processar a requisição.', 500);
+  }
+}
+
+export async function GET(request: NextRequest) {
+  const auth = authenticateRequest(request);
+  if (auth instanceof Response) {
+    return auth;
+  }
+
+  const searchParams = request.nextUrl.searchParams;
+  const nome = searchParams.get('nome');
+  const visivel = searchParams.get('visivel');
+  const areaConhecimentoId = searchParams.get('areaConhecimentoId');
+  const campusId = searchParams.get('campusId');
+  const page = Number(searchParams.get('page') ?? '0');
+  const size = Number(searchParams.get('size') ?? '10');
+  const direction = (searchParams.get('direction') ?? 'desc').toLowerCase();
+
+  let items = [...db.courses];
+
+  if (nome) {
+    items = items.filter((item) => item.name.toLowerCase().includes(nome.toLowerCase()));
+  }
+
+  if (visivel && ['true', 'false'].includes(visivel.toLowerCase())) {
+    const visibleFlag = visivel.toLowerCase() === 'true';
+    items = items.filter((item) => item.visible === visibleFlag);
+  }
+
+  if (areaConhecimentoId) {
+    items = items.filter((item) => item.knowledgeAreaId === Number(areaConhecimentoId));
+  }
+
+  if (campusId) {
+    items = items.filter((item) => item.campusId === Number(campusId));
+  }
+
+  items.sort((a, b) => {
+    const directionMultiplier = direction === 'asc' ? 1 : -1;
+    return directionMultiplier * (new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
+  });
+
+  const result = paginate(items, Number.isNaN(page) ? 0 : page, Number.isNaN(size) ? 10 : size);
+
+  return jsonResponse({
+    ...result,
+    content: result.content.map((course) => serializeCourse(getCourseById(course.id))),
+  });
+}

--- a/src/app/api/enrollments/[enrollmentId]/lessons/[lessonId]/progress/route.ts
+++ b/src/app/api/enrollments/[enrollmentId]/lessons/[lessonId]/progress/route.ts
@@ -1,0 +1,77 @@
+import { NextRequest } from 'next/server';
+import { authenticateRequest } from '../../../../../_lib/auth';
+import { createTimestamp, db } from '../../../../../_lib/store';
+import { errorResponse, jsonResponse } from '../../../../../_lib/utils';
+import { getCourseById } from '../../../../courses/_utils';
+import { createProgressEntry, recalculateEnrollmentStatus, serializeEnrollment } from '../../../../enrollments/_utils';
+
+const parseId = (value: string) => {
+  const id = Number(value);
+  return Number.isNaN(id) ? null : id;
+};
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { enrollmentId: string; lessonId: string } },
+) {
+  const auth = authenticateRequest(request);
+  if (auth instanceof Response) {
+    return auth;
+  }
+
+  const enrollmentId = parseId(params.enrollmentId);
+  const lessonId = parseId(params.lessonId);
+
+  if (enrollmentId === null || lessonId === null) {
+    return errorResponse('Identificadores inválidos.', 400);
+  }
+
+  const enrollment = db.enrollments.find((item) => item.id === enrollmentId);
+  if (!enrollment) {
+    return errorResponse('Matrícula não encontrada.', 404);
+  }
+
+  if (auth.user.role !== 'admin' && enrollment.userId !== auth.user.id) {
+    return errorResponse('Usuário sem permissão para atualizar esta matrícula.', 403);
+  }
+
+  const course = getCourseById(enrollment.cursoId);
+  if (!course) {
+    return errorResponse('Curso vinculado não encontrado.', 404);
+  }
+
+  const lesson = db.lessons.find((item) => item.courseId === course.id && item.id === lessonId);
+  if (!lesson) {
+    return errorResponse('Aula não pertence ao curso informado.', 404);
+  }
+
+  try {
+    const body = await request.json();
+    const { concluido } = body ?? {};
+
+    if (typeof concluido !== 'boolean') {
+      return errorResponse('Campo "concluido" é obrigatório.', 400);
+    }
+
+    let progress = db.lessonProgress.find(
+      (item) => item.enrollmentId === enrollmentId && item.lessonId === lessonId,
+    );
+
+    if (progress) {
+      progress.concluido = concluido;
+      progress.updatedAt = createTimestamp();
+    } else {
+      progress = createProgressEntry(enrollmentId, lessonId, concluido);
+    }
+
+    recalculateEnrollmentStatus(enrollment);
+
+    return jsonResponse({
+      enrollment: serializeEnrollment(enrollment),
+      progress,
+    });
+  } catch (error) {
+    console.error(error);
+    return errorResponse('Não foi possível processar a requisição.', 500);
+  }
+}

--- a/src/app/api/enrollments/_utils.ts
+++ b/src/app/api/enrollments/_utils.ts
@@ -1,0 +1,65 @@
+import { counters, createTimestamp, db } from '../_lib/store';
+import { Enrollment } from '../_lib/types';
+import { getCourseById, serializeCourse } from '../courses/_utils';
+
+export const recalculateEnrollmentStatus = (enrollment: Enrollment) => {
+  const lessons = db.lessons.filter((lesson) => lesson.courseId === enrollment.cursoId);
+
+  const previousStatus = enrollment.concluido;
+
+  if (!lessons.length) {
+    enrollment.concluido = false;
+  } else {
+    const completedLessons = lessons.filter((lesson) =>
+      db.lessonProgress.some(
+        (progress) => progress.enrollmentId === enrollment.id && progress.lessonId === lesson.id && progress.concluido,
+      ),
+    );
+
+    enrollment.concluido = completedLessons.length === lessons.length;
+  }
+
+  if (enrollment.concluido !== previousStatus) {
+    enrollment.updatedAt = createTimestamp();
+  }
+};
+
+export const serializeEnrollment = (enrollment: Enrollment) => {
+  const course = getCourseById(enrollment.cursoId);
+  recalculateEnrollmentStatus(enrollment);
+
+  const lessons = db.lessons.filter((lesson) => lesson.courseId === enrollment.cursoId);
+  const progress = lessons.map((lesson) => {
+    const lessonProgress = db.lessonProgress.find(
+      (item) => item.enrollmentId === enrollment.id && item.lessonId === lesson.id,
+    );
+
+    return {
+      lessonId: lesson.id,
+      concluido: lessonProgress?.concluido ?? false,
+      updatedAt: lessonProgress?.updatedAt ?? null,
+    };
+  });
+
+  return {
+    ...enrollment,
+    course: serializeCourse(course),
+    progress,
+  };
+};
+
+export const createProgressEntry = (enrollmentId: number, lessonId: number, concluido: boolean) => {
+  const id = counters.lessonProgress;
+  const timestamp = createTimestamp();
+
+  const progress = {
+    id,
+    enrollmentId,
+    lessonId,
+    concluido,
+    updatedAt: timestamp,
+  };
+
+  db.lessonProgress.push(progress);
+  return progress;
+};

--- a/src/app/api/enrollments/my-courses/route.ts
+++ b/src/app/api/enrollments/my-courses/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest } from 'next/server';
+import { authenticateRequest } from '../../_lib/auth';
+import { db } from '../../_lib/store';
+import { jsonResponse, paginate } from '../../_lib/utils';
+import { recalculateEnrollmentStatus, serializeEnrollment } from '../_utils';
+
+export async function GET(request: NextRequest) {
+  const auth = authenticateRequest(request);
+  if (auth instanceof Response) {
+    return auth;
+  }
+
+  const searchParams = request.nextUrl.searchParams;
+  const nome = searchParams.get('nome');
+  const concluido = searchParams.get('concluido');
+  const page = Number(searchParams.get('page') ?? '0');
+  const size = Number(searchParams.get('size') ?? '10');
+  const direction = (searchParams.get('direction') ?? 'desc').toLowerCase();
+
+  let items = db.enrollments.filter((enrollment) => enrollment.userId === auth.user.id);
+
+  items.forEach((enrollment) => recalculateEnrollmentStatus(enrollment));
+
+  if (nome) {
+    items = items.filter((enrollment) => {
+      const course = db.courses.find((courseItem) => courseItem.id === enrollment.cursoId);
+      return course?.name.toLowerCase().includes(nome.toLowerCase());
+    });
+  }
+
+  if (concluido && ['true', 'false'].includes(concluido.toLowerCase())) {
+    const concluidoFlag = concluido.toLowerCase() === 'true';
+    items = items.filter((enrollment) => enrollment.concluido === concluidoFlag);
+  }
+
+  items.sort((a, b) => {
+    const directionMultiplier = direction === 'asc' ? 1 : -1;
+    return directionMultiplier * (new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
+  });
+
+  const result = paginate(items, Number.isNaN(page) ? 0 : page, Number.isNaN(size) ? 10 : size);
+
+  return jsonResponse({
+    ...result,
+    content: result.content.map((enrollment) => serializeEnrollment(enrollment)),
+  });
+}

--- a/src/app/api/enrollments/route.ts
+++ b/src/app/api/enrollments/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest } from 'next/server';
+import { authenticateRequest } from '../_lib/auth';
+import { counters, createTimestamp, db } from '../_lib/store';
+import { errorResponse, jsonResponse } from '../_lib/utils';
+import { getCourseById } from '../courses/_utils';
+import { serializeEnrollment } from './_utils';
+
+export async function POST(request: NextRequest) {
+  const auth = authenticateRequest(request);
+  if (auth instanceof Response) {
+    return auth;
+  }
+
+  try {
+    const body = await request.json();
+    const { cursoId } = body ?? {};
+
+    if (!cursoId) {
+      return errorResponse('Campo "cursoId" é obrigatório.', 400);
+    }
+
+    const course = getCourseById(Number(cursoId));
+    if (!course) {
+      return errorResponse('Curso não encontrado.', 404);
+    }
+
+    const existingEnrollment = db.enrollments.find((item) => item.userId === auth.user.id && item.cursoId === course.id);
+
+    if (existingEnrollment) {
+      return jsonResponse({ enrollment: serializeEnrollment(existingEnrollment) });
+    }
+
+    const id = counters.enrollment;
+    const timestamp = createTimestamp();
+
+    const enrollment = {
+      id,
+      userId: auth.user.id,
+      cursoId: course.id,
+      concluido: false,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    };
+
+    db.enrollments.push(enrollment);
+
+    return jsonResponse({ enrollment: serializeEnrollment(enrollment) }, 201);
+  } catch (error) {
+    console.error(error);
+    return errorResponse('Não foi possível processar a requisição.', 500);
+  }
+}

--- a/src/app/api/knowledge-area/route.ts
+++ b/src/app/api/knowledge-area/route.ts
@@ -1,0 +1,82 @@
+import { NextRequest } from 'next/server';
+import { authenticateRequest } from '../_lib/auth';
+import { counters, createTimestamp, db } from '../_lib/store';
+import { errorResponse, jsonResponse, paginate } from '../_lib/utils';
+
+export async function POST(request: NextRequest) {
+  const auth = authenticateRequest(request, ['admin']);
+  if (auth instanceof Response) {
+    return auth;
+  }
+
+  try {
+    const body = await request.json();
+    const { name, visible } = body ?? {};
+
+    if (!name || typeof visible !== 'boolean') {
+      return errorResponse('Campos "name" e "visible" são obrigatórios.', 400);
+    }
+
+    const exists = db.knowledgeAreas.some((item) => item.name.toLowerCase() === String(name).toLowerCase());
+
+    if (exists) {
+      return errorResponse('Área de conhecimento já cadastrada.', 409);
+    }
+
+    const id = counters.knowledgeArea;
+    const timestamp = createTimestamp();
+
+    const knowledgeArea = {
+      id,
+      name,
+      visible,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    };
+
+    db.knowledgeAreas.push(knowledgeArea);
+
+    return jsonResponse({ knowledgeArea }, 201);
+  } catch (error) {
+    console.error(error);
+    return errorResponse('Não foi possível processar a requisição.', 500);
+  }
+}
+
+export async function GET(request: NextRequest) {
+  const auth = authenticateRequest(request);
+  if (auth instanceof Response) {
+    return auth;
+  }
+
+  const searchParams = request.nextUrl.searchParams;
+  const name = searchParams.get('name');
+  const active = searchParams.get('active');
+  const page = Number(searchParams.get('page') ?? '0');
+  const size = Number(searchParams.get('size') ?? '10');
+  const direction = (searchParams.get('direction') ?? 'asc').toLowerCase();
+
+  let items = [...db.knowledgeAreas];
+
+  if (name) {
+    items = items.filter((item) => item.name.toLowerCase().includes(name.toLowerCase()));
+  }
+
+  if (active !== null) {
+    if (['true', 'false'].includes(active.toLowerCase())) {
+      const activeFlag = active.toLowerCase() === 'true';
+      items = items.filter((item) => item.visible === activeFlag);
+    }
+  }
+
+  items.sort((a, b) => {
+    if (direction === 'desc') {
+      return b.name.localeCompare(a.name);
+    }
+    return a.name.localeCompare(b.name);
+  });
+
+  const result = paginate(items, Number.isNaN(page) ? 0 : page, Number.isNaN(size) ? 10 : size);
+
+  return jsonResponse(result);
+}

--- a/src/app/api/users/register/route.ts
+++ b/src/app/api/users/register/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest } from 'next/server';
+import { counters, createTimestamp, db } from '../../_lib/store';
+import { errorResponse, jsonResponse } from '../../_lib/utils';
+
+const sanitizeUser = (userId: number) => {
+  const user = db.users.find((item) => item.id === userId);
+  if (!user) {
+    return null;
+  }
+
+  const { password: _password, ...publicUser } = user;
+  void _password;
+  return publicUser;
+};
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { fullName, cpf, birthDate, email, password } = body ?? {};
+
+    if (!fullName || !cpf || !birthDate || !email || !password) {
+      return errorResponse('Todos os campos são obrigatórios.', 400);
+    }
+
+    const existingUser = db.users.find((item) => item.email.toLowerCase() === String(email).toLowerCase());
+
+    if (existingUser) {
+      return errorResponse('E-mail já cadastrado.', 409);
+    }
+
+    const id = counters.user;
+    const timestamp = createTimestamp();
+
+    db.users.push({
+      id,
+      fullName,
+      cpf,
+      birthDate,
+      email,
+      password,
+      role: 'student',
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    });
+
+    return jsonResponse({ user: sanitizeUser(id) }, 201);
+  } catch (error) {
+    console.error(error);
+    return errorResponse('Não foi possível processar a requisição.', 500);
+  }
+}


### PR DESCRIPTION
## Summary
- add shared in-memory data store and auth helpers for new API routes
- implement registration, authentication, and catalog endpoints for users, knowledge areas, campus, and courses
- provide lesson management, enrollments, and progress tracking handlers backed by the in-memory store

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f7916b5980832aa26ee4147181a7d0