### PR TITLE
Implement student self-registration flow

### DIFF
--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -61,7 +61,7 @@ export async function login(payload: LoginPayload) {
 }
 
 export async function registerUser(payload: RegisterPayload) {
-  return apiRequest<unknown>("/users/register", {
+  return apiRequest<unknown>("/auth/cadastro", {
     method: "POST",
     body: JSON.stringify(payload),
   });


### PR DESCRIPTION
## Summary
- adjust the authentication service to use the new /auth/cadastro endpoint for registrations
- update the student registration form to log the user in, persist the token cookie, and redirect to the appropriate dashboard

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_690022b0b730832a9db195688a1b1517