### PR TITLE
Fix register endpoint path for user registration

### DIFF
--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -61,7 +61,7 @@ export async function login(payload: LoginPayload) {
 }
 
 export async function registerUser(payload: RegisterPayload) {
-  return apiRequest<unknown>("/auth/cadastro", {
+  return apiRequest<unknown>("/users/register", {
     method: "POST",
     body: JSON.stringify(payload),
   });


### PR DESCRIPTION
## Summary
- point the registerUser service to the backend /users/register endpoint
- ensure new account creation uses the correct API route

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_6901516809b8832ab955c3b9b53b60dd